### PR TITLE
fix(pick-random): open random link from content-menu

### DIFF
--- a/src/components/Topic/Topic.js
+++ b/src/components/Topic/Topic.js
@@ -527,6 +527,7 @@ function RandomButton({ data }) {
 		<Button
 			className='pick-random-btn'
 			onClick={pickRandomHandler}
+			onContextMenu={pickRandomHandler}
 			variant='outline-primary'
 			href={data.questions[rnd].URL}
 			target='_blank'


### PR DESCRIPTION
Hello @AsishRaju I appreciate this project, a small fix from my side

## Issue:
When we right-click on **Pick Random** button and click **Open Link in New Tab**, it does not pick random URL rather picks href tag (which makes sense)
But from the user-experience wise it doesn't seems right.

## Fix:
In this PR, we are updating href on right-click event also